### PR TITLE
Start running tests in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git/
 data-raw/
 figure/
-tests/
 vignettes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /home/ghgvcr/lib
 ENV R_LIBS_USER /home/ghgvcr/lib
 
 # install R dependency packages
-RUN Rscript -e "install.packages(c('ggplot2', 'gridExtra', 'Hmisc', 'jsonlite', 'scales', 'tidyr', 'ncdf4', 'Rserve', 'XML'), repos = 'http://cran.us.r-project.org')"
+RUN Rscript -e "install.packages(c('ggplot2', 'gridExtra', 'Hmisc', 'jsonlite', 'scales', 'tidyr', 'ncdf4', 'Rserve', 'XML', 'readr', 'rmarkdown', 'testthat'), repos = 'http://cran.us.r-project.org')"
 
 # place the ghgvcR project into the image
 COPY . $HOME

--- a/README.Rmd
+++ b/README.Rmd
@@ -145,3 +145,13 @@ project.
              --name ghgvcr-serve \ # name the running container
              ebimodeling/ghgvcr    # the tag given during `docker build ...`
 ```
+
+## Running R tests for local development
+
+1. Remove `tests/` from `.dockerignore` if it is present
+2. Run `docker build .` in the project's root directory
+3. Get a shell into the container with `docker run -it <id from step 2> /bin/bash`
+4. Inside the container, run `R CMD build .` to generate the tarball used by the checker
+(note the trailing `.`)
+5. Run `R CMD check ghgvcr_2.0.tar.gz --as-cran --no-manual --no-manual` This checks the
+R code, and should report no errors.


### PR DESCRIPTION
Changes .dockerignore, Dockerfile, and README.Rmd, so that
'testthat' can be run by developers on their local machine
before it fails in the pipeline.